### PR TITLE
Fix deposit scaling and negative balance messaging

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,8 +52,8 @@ export type TimelineEntry = {
 export type SimResult = {
   minBalance: number;
   endBalance: number;
-  requiredMonthlyA: number;
-  requiredMonthlyB?: number;
+  requiredDepositA: number;
+  requiredDepositB?: number;
   entries: TimelineEntry[];
   billSuggestions?: Array<{
     billId: string;


### PR DESCRIPTION
## Summary
- use per-pay deposits from optimization engine and convert monthly fallback only when needed
- show alert when optimized deposits still lead to a negative balance
- rename simulation result fields to reflect per-pay deposits

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab70ed16fc8322843366a4577e89c5