### PR TITLE
fix: align deposits before bills and correct pay schedule

### DIFF
--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -26,7 +26,7 @@ export function nextBusinessDayISO(d: Date): string {
 /**
  * Generate pay dates.
  * - weekly/fortnightly/four_weekly: step forward from start date
- * - monthly: **1st of the following month**, rolled to next business day
+ * - monthly: advance one month at a time from the provided start date
  */
 export function payDates(startISO: string, freq: PayFrequency, months = 12): string[] {
   const today = new Date();
@@ -46,10 +46,11 @@ export function payDates(startISO: string, freq: PayFrequency, months = 12): str
     return out;
   }
 
-  // ✅ Monthly: first business day of the month AFTER today
-  const firstOfNext = new Date(today.getFullYear(), today.getMonth() + 1, 1);
+  // Monthly: step forward one month at a time from the anchor date
+  let d = start;
+  while (d <= today) d = new Date(d.getFullYear(), d.getMonth() + 1, d.getDate());
   for (let i = 0; i < months; i++) {
-    const raw = new Date(firstOfNext.getFullYear(), firstOfNext.getMonth() + i, 1);
+    const raw = new Date(d.getFullYear(), d.getMonth() + i, d.getDate());
     out.push(formatISO(nextBusinessDay(raw), { representation: "date" }));
   }
   return out;


### PR DESCRIPTION
## Summary
- base monthly pay schedules on the provided anchor date instead of the current month
- start simulations on the first deposit so bills never precede funding
- align optimisation scenarios to deposit dates for both single and joint plans

## Testing
- `npm run lint` *(fails: Unnecessary escape character, Unexpected any, etc.)*
- `npx eslint src/lib/dateUtils.ts src/services/optimizationEngine.ts`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aba2d8adc483229926d7560c8e1d1f