### PR TITLE
roll bills before first payday

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -324,7 +324,12 @@ setState(prev => ({
 
     try {
       const selectedBills = currentState.bills.filter(b => currentState.includedBillIds.includes(b.id!));
-      const allBills = rollForwardPastBills(selectedBills);
+      const firstPayDate = currentState.userB?.paySchedule
+        ? (currentState.userA.paySchedule!.anchorDate < currentState.userB.paySchedule.anchorDate
+            ? currentState.userA.paySchedule!.anchorDate
+            : currentState.userB.paySchedule.anchorDate)
+        : currentState.userA.paySchedule!.anchorDate;
+      const allBills = rollForwardPastBills(selectedBills, firstPayDate);
 
       const startDateA = getStartDate(currentState.userA.paySchedule!, allBills);
       const payScheduleA: PaySchedule = { ...currentState.userA.paySchedule!, anchorDate: startDateA };

--- a/src/utils/billUtils.ts
+++ b/src/utils/billUtils.ts
@@ -11,20 +11,21 @@ export interface Bill {
 }
 
 /**
- * Rolls imported bills forward to their next occurrence if their due date is in the past
+ * Rolls imported bills forward to their next occurrence if their due date is
+ * before a given reference date. Defaults to today's date.
  */
-export function rollForwardPastBills(bills: Bill[]): Bill[] {
-  const today = new Date().toISOString().split('T')[0];
+export function rollForwardPastBills(bills: Bill[], referenceDate?: string): Bill[] {
+  const ref = referenceDate ?? new Date().toISOString().split('T')[0];
 
   return bills.map(bill => {
-    // If the bill is not past due, return as is
-    if (bill.dueDate >= today) {
+    // If the bill is not before the reference date, return as is
+    if (bill.dueDate >= ref) {
       return bill;
     }
 
     // Assume past-due bills recur monthly and roll them forward
     const nextOccurrences = generateOccurrences(bill.dueDate, 'monthly', 24);
-    const nextDueDate = nextOccurrences.find(date => date >= today);
+    const nextDueDate = nextOccurrences.find(date => date >= ref);
 
     if (nextDueDate) {
       return {


### PR DESCRIPTION
## Summary
- ensure bills are rolled forward relative to earliest payday
- pass earliest wage date when rolling bills to avoid pre-payday charges

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aba76c4e18832284574bb326a61f1f