### PR TITLE
feat: add GoCardless integration with env toggle

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,2 @@
+export const USE_MOCK_GC = import.meta.env.VITE_USE_MOCK_GC === 'true';
+export const GC_API_BASE_URL = import.meta.env.VITE_GC_API_BASE_URL || 'https://bankaccountdata.gocardless.com';

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,6 +39,8 @@ import { rollForwardPastBills } from '@/utils/billUtils';
 import type { RecurringItem, SalaryCandidate, SavingsPot, SimResult, PlanInputs } from '@/types';
 import { useToast } from '@/components/ui/use-toast';
 import { expandRecurring } from '../lib/expandRecurring';
+import { USE_MOCK_GC } from '@/config';
+import { startGcLink, fetchGcTransactions } from '@/services/gc';
 
 // UI metadata used to render the Pattern column (keep anchor, drop "last …")
 type RecurringMeta = Record<
@@ -112,56 +114,103 @@ const [state, setState] = useState<AppState>({
   const recurringFromStore: RecurringItem[] = detected?.recurring ?? [];
   const recurringFromStoreB: RecurringItem[] = (detected as any)?.recurringB ?? [];
 
-
-  // Load mock bank data
-  const loadBankData = async (mode: 'single' | 'joint') => {
-           setState(prev => ({ ...prev, isLoading: true }));
-    
-    try {
-      const transactionsA = await loadMockTransactionsA();
-      const categorizedA = categorizeBankTransactions(transactionsA);
-      const payScheduleA = extractPayScheduleFromWages(categorizedA.wages);
-
-      let userB = undefined;
-      if (mode === 'joint') {
-        const transactionsB = await loadMockTransactionsB();
-        const categorizedB = categorizeBankTransactions(transactionsB);
-        const payScheduleB = extractPayScheduleFromWages(categorizedB.wages);
-        userB = { transactions: transactionsB, paySchedule: payScheduleB };
+  // When returning from GoCardless redirect, pull real transactions
+  useEffect(() => {
+    if (USE_MOCK_GC) return;
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('gc') === '1') {
+      const requisitionId = localStorage.getItem('gc_requisition_id');
+      if (requisitionId) {
+        (async () => {
+          setState(prev => ({ ...prev, isLoading: true }));
+          try {
+            const transactions = await fetchGcTransactions(requisitionId);
+            const categorizedA = categorizeBankTransactions(transactions);
+            const payScheduleA = extractPayScheduleFromWages(categorizedA.wages);
+            setState(prev => ({
+              ...prev,
+              mode: 'single',
+              userA: { transactions, paySchedule: payScheduleA },
+              step: 'bank',
+              isLoading: false,
+            }));
+            const runDetection = (window as any).__runDetection;
+            if (runDetection) await runDetection(transactions);
+          } catch (err) {
+            console.error('Failed to fetch GoCardless transactions:', err);
+            setState(prev => ({ ...prev, isLoading: false }));
+          } finally {
+            localStorage.removeItem('gc_requisition_id');
+            url.searchParams.delete('gc');
+            window.history.replaceState(null, '', url.toString());
+          }
+        })();
       }
+    }
+  }, []);
 
-      // ❌ Don’t seed UI bills from mock categorisation.
-      // We want the worker’s detections to be the source of truth shown in the table.
+
+  // Load bank data, using mock fixtures or GoCardless based on env
+  const loadBankData = async (mode: 'single' | 'joint') => {
+    setState(prev => ({ ...prev, isLoading: true }));
+
+    if (USE_MOCK_GC) {
+      try {
+        const transactionsA = await loadMockTransactionsA();
+        const categorizedA = categorizeBankTransactions(transactionsA);
+        const payScheduleA = extractPayScheduleFromWages(categorizedA.wages);
+
+        let userB = undefined;
+        if (mode === 'joint') {
+          const transactionsB = await loadMockTransactionsB();
+          const categorizedB = categorizeBankTransactions(transactionsB);
+          const payScheduleB = extractPayScheduleFromWages(categorizedB.wages);
+          userB = { transactions: transactionsB, paySchedule: payScheduleB };
+        }
+
+        // ❌ Don’t seed UI bills from mock categorisation.
+        // We want the worker’s detections to be the source of truth shown in the table.
 
         setState(prev => ({
-  ...prev,
-  mode,
-  userA: { transactions: transactionsA, paySchedule: payScheduleA },
-  userB,
-  // ⚠️ Keep whatever the worker may have already populated
-  bills: prev.bills,
-  includedBillIds: prev.includedBillIds,
-  isLoading: false,
-  step: 'bank'
-}));
+          ...prev,
+          mode,
+          userA: { transactions: transactionsA, paySchedule: payScheduleA },
+          userB,
+          // ⚠️ Keep whatever the worker may have already populated
+          bills: prev.bills,
+          includedBillIds: prev.includedBillIds,
+          isLoading: false,
+          step: 'bank'
+        }));
 
-      // 🔌 NEW: Trigger worker detection system
-      const switchToJointMode = (window as any).__switchToJointMode;
-      const runDetection = (window as any).__runDetection;
-      
-      if (mode === 'joint' && switchToJointMode) {
-        console.log('[loadBankData] Triggering joint mode detection...');
-        await switchToJointMode();
-      } else if (mode === 'single' && runDetection) {
-        console.log('[loadBankData] Triggering single mode detection...');
-        const { mapBoiToTransactions } = await import('../lib/txMap');
-        const mockA = await import('../fixtures/mock-a-boi-transactions.json');
-        const txA = mapBoiToTransactions(mockA as any);
-        await runDetection(txA);
+        // 🔌 NEW: Trigger worker detection system
+        const switchToJointMode = (window as any).__switchToJointMode;
+        const runDetection = (window as any).__runDetection;
+
+        if (mode === 'joint' && switchToJointMode) {
+          console.log('[loadBankData] Triggering joint mode detection...');
+          await switchToJointMode();
+        } else if (mode === 'single' && runDetection) {
+          console.log('[loadBankData] Triggering single mode detection...');
+          const { mapBoiToTransactions } = await import('../lib/txMap');
+          const mockA = await import('../fixtures/mock-a-boi-transactions.json');
+          const txA = mapBoiToTransactions(mockA as any);
+          await runDetection(txA);
+        }
+      } catch (error) {
+        console.error('Failed to load bank data:', error);
+        setState(prev => ({ ...prev, isLoading: false }));
       }
-    } catch (error) {
-      console.error('Failed to load bank data:', error);
-      setState(prev => ({ ...prev, isLoading: false }));
+    } else {
+      try {
+        const redirect = `${window.location.origin}?gc=1`;
+        const { link, requisition_id } = await startGcLink(redirect, 'BANK_OF_IRELAND');
+        localStorage.setItem('gc_requisition_id', requisition_id);
+        window.location.href = link;
+      } catch (error) {
+        console.error('Failed to start bank link:', error);
+        setState(prev => ({ ...prev, isLoading: false }));
+      }
     }
   };
 
@@ -769,20 +818,22 @@ const [state, setState] = useState<AppState>({
                   disabled={state.isLoading}
                 >
                   <Calculator className="w-6 h-6" />
-                  <span className="font-medium">Single Account</span>
-                  <span className="text-xs text-muted-foreground">Individual forecasting</span>
+                  <span className="font-medium">Link Account</span>
+                  <span className="text-xs text-muted-foreground">Fetch real transactions</span>
                 </Button>
-                
-                <Button
-                  variant="outline"
-                  className="h-24 flex flex-col space-y-2"
-                  onClick={() => loadBankData('joint')}
-                  disabled={state.isLoading}
-                >
-                  <Users className="w-6 h-6" />
-                  <span className="font-medium">Joint Account</span>
-                  <span className="text-xs text-muted-foreground">Couple's forecasting</span>
-                </Button>
+
+                {USE_MOCK_GC && (
+                  <Button
+                    variant="outline"
+                    className="h-24 flex flex-col space-y-2"
+                    onClick={() => loadBankData('joint')}
+                    disabled={state.isLoading}
+                  >
+                    <Users className="w-6 h-6" />
+                    <span className="font-medium">Joint Account</span>
+                    <span className="text-xs text-muted-foreground">Couple's forecasting</span>
+                  </Button>
+                )}
               </div>
               
               {state.isLoading && (

--- a/src/services/gc.ts
+++ b/src/services/gc.ts
@@ -1,0 +1,19 @@
+import { supabase } from '@/integrations/supabase/client';
+import { mapBoiToTransactions } from '@/lib/txMap';
+import type { Transaction } from '@/types';
+
+export async function startGcLink(redirect: string, institutionId: string) {
+  const { data, error } = await supabase.functions.invoke('gc-link', {
+    body: { redirect, institutionId },
+  });
+  if (error) throw new Error(error.message);
+  return data as { link: string; requisition_id: string };
+}
+
+export async function fetchGcTransactions(requisitionId: string): Promise<Transaction[]> {
+  const { data, error } = await supabase.functions.invoke('gc-pull', {
+    body: { requisitionId },
+  });
+  if (error) throw new Error(error.message);
+  return mapBoiToTransactions((data as any).transactions);
+}

--- a/supabase/functions/gc-link/index.ts
+++ b/supabase/functions/gc-link/index.ts
@@ -1,0 +1,49 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+};
+
+function json(body: unknown, init?: ResponseInit) {
+  const base: ResponseInit = { headers: { ...corsHeaders, "Content-Type": "application/json" } };
+  return new Response(JSON.stringify(body), { ...base, ...init, headers: { ...base.headers, ...(init?.headers || {}) } });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+
+  const { institutionId, redirect } = await req.json();
+
+  const id = Deno.env.get("GC_SECRET_ID");
+  const key = Deno.env.get("GC_SECRET_KEY");
+  const base = Deno.env.get("GC_API_BASE_URL") || "https://bankaccountdata.gocardless.com";
+  if (!id || !key) return json({ error: "Missing GoCardless credentials" }, { status: 500 });
+
+  // get access token
+  const tokenResp = await fetch(`${base}/api/v2/token/new/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret_id: id, secret_key: key }),
+  });
+  if (!tokenResp.ok) return json({ error: "token fetch failed", detail: await tokenResp.text() }, { status: 500 });
+  const { access } = await tokenResp.json();
+
+  const reference = crypto.randomUUID();
+
+  const reqResp = await fetch(`${base}/api/v2/requisitions/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${access}` },
+    body: JSON.stringify({
+      institution_id: institutionId,
+      redirect,
+      reference,
+    }),
+  });
+  if (!reqResp.ok) return json({ error: "requisition failed", detail: await reqResp.text() }, { status: 500 });
+  const data = await reqResp.json();
+
+  return json({ link: data.link, requisition_id: data.id });
+});

--- a/supabase/functions/gc-pull/index.ts
+++ b/supabase/functions/gc-pull/index.ts
@@ -1,0 +1,47 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+};
+
+function json(body: unknown, init?: ResponseInit) {
+  const base: ResponseInit = { headers: { ...corsHeaders, "Content-Type": "application/json" } };
+  return new Response(JSON.stringify(body), { ...base, ...init, headers: { ...base.headers, ...(init?.headers || {}) } });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+
+  const { requisitionId } = await req.json();
+
+  const id = Deno.env.get("GC_SECRET_ID");
+  const key = Deno.env.get("GC_SECRET_KEY");
+  const base = Deno.env.get("GC_API_BASE_URL") || "https://bankaccountdata.gocardless.com";
+  if (!id || !key) return json({ error: "Missing GoCardless credentials" }, { status: 500 });
+
+  const tokenResp = await fetch(`${base}/api/v2/token/new/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret_id: id, secret_key: key }),
+  });
+  if (!tokenResp.ok) return json({ error: "token fetch failed", detail: await tokenResp.text() }, { status: 500 });
+  const { access } = await tokenResp.json();
+
+  const reqResp = await fetch(`${base}/api/v2/requisitions/${requisitionId}/`, {
+    headers: { Authorization: `Bearer ${access}` },
+  });
+  if (!reqResp.ok) return json({ error: "requisition lookup failed", detail: await reqResp.text() }, { status: 500 });
+  const reqData = await reqResp.json();
+  const accountId = reqData.accounts?.[0];
+  if (!accountId) return json({ error: "No accounts found on requisition" }, { status: 400 });
+
+  const txResp = await fetch(`${base}/api/v2/accounts/${accountId}/transactions/`, {
+    headers: { Authorization: `Bearer ${access}` },
+  });
+  if (!txResp.ok) return json({ error: "transactions fetch failed", detail: await txResp.text() }, { status: 500 });
+  const txData = await txResp.json();
+  return json({ transactions: txData });
+});


### PR DESCRIPTION
## Summary
- add env-driven switch between mock data and live GoCardless flow
- implement Supabase Edge functions for GoCardless requisition and transaction pull
- wire UI to trigger linking and process returned transactions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae4f7de8e88322822459995872a6a0