### PR TITLE
feat: move bank linking to bank step

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,2 @@
+export const USE_MOCK_GC = import.meta.env.VITE_USE_MOCK_GC === 'true';
+export const GC_API_BASE_URL = import.meta.env.VITE_GC_API_BASE_URL || 'https://bankaccountdata.gocardless.com';

--- a/src/services/gc.ts
+++ b/src/services/gc.ts
@@ -1,0 +1,25 @@
+import { supabase } from '@/integrations/supabase/client';
+import { mapBoiToTransactions } from '@/lib/txMap';
+import type { Transaction } from '@/types';
+
+export async function startGcLink(redirect: string, institutionId: string) {
+  const { data, error } = await supabase.functions.invoke('gc-link', {
+    body: { redirect, institutionId },
+  });
+  if (error || !data) {
+    const message = (data as any)?.error || error?.message || 'Unknown error';
+    throw new Error(message);
+  }
+  return data as { link: string; requisition_id: string };
+}
+
+export async function fetchGcTransactions(requisitionId: string): Promise<Transaction[]> {
+  const { data, error } = await supabase.functions.invoke('gc-pull', {
+    body: { requisitionId },
+  });
+  if (error || !data) {
+    const message = (data as any)?.error || error?.message || 'Unknown error';
+    throw new Error(message);
+  }
+  return mapBoiToTransactions((data as any).transactions);
+}

--- a/supabase/functions/gc-link/index.ts
+++ b/supabase/functions/gc-link/index.ts
@@ -1,0 +1,49 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+};
+
+function json(body: unknown, init?: ResponseInit) {
+  const base: ResponseInit = { headers: { ...corsHeaders, "Content-Type": "application/json" } };
+  return new Response(JSON.stringify(body), { ...base, ...init, headers: { ...base.headers, ...(init?.headers || {}) } });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+
+  const { institutionId, redirect } = await req.json();
+
+  const id = Deno.env.get("GC_SECRET_ID");
+  const key = Deno.env.get("GC_SECRET_KEY");
+  const base = Deno.env.get("GC_API_BASE_URL") || "https://bankaccountdata.gocardless.com";
+  if (!id || !key) return json({ error: "Missing GoCardless credentials" }, { status: 500 });
+
+  // get access token
+  const tokenResp = await fetch(`${base}/api/v2/token/new/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret_id: id, secret_key: key }),
+  });
+  if (!tokenResp.ok) return json({ error: "token fetch failed", detail: await tokenResp.text() }, { status: 500 });
+  const { access } = await tokenResp.json();
+
+  const reference = crypto.randomUUID();
+
+  const reqResp = await fetch(`${base}/api/v2/requisitions/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${access}` },
+    body: JSON.stringify({
+      institution_id: institutionId,
+      redirect,
+      reference,
+    }),
+  });
+  if (!reqResp.ok) return json({ error: "requisition failed", detail: await reqResp.text() }, { status: 500 });
+  const data = await reqResp.json();
+
+  return json({ link: data.link, requisition_id: data.id });
+});

--- a/supabase/functions/gc-pull/index.ts
+++ b/supabase/functions/gc-pull/index.ts
@@ -1,0 +1,47 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+};
+
+function json(body: unknown, init?: ResponseInit) {
+  const base: ResponseInit = { headers: { ...corsHeaders, "Content-Type": "application/json" } };
+  return new Response(JSON.stringify(body), { ...base, ...init, headers: { ...base.headers, ...(init?.headers || {}) } });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+
+  const { requisitionId } = await req.json();
+
+  const id = Deno.env.get("GC_SECRET_ID");
+  const key = Deno.env.get("GC_SECRET_KEY");
+  const base = Deno.env.get("GC_API_BASE_URL") || "https://bankaccountdata.gocardless.com";
+  if (!id || !key) return json({ error: "Missing GoCardless credentials" }, { status: 500 });
+
+  const tokenResp = await fetch(`${base}/api/v2/token/new/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret_id: id, secret_key: key }),
+  });
+  if (!tokenResp.ok) return json({ error: "token fetch failed", detail: await tokenResp.text() }, { status: 500 });
+  const { access } = await tokenResp.json();
+
+  const reqResp = await fetch(`${base}/api/v2/requisitions/${requisitionId}/`, {
+    headers: { Authorization: `Bearer ${access}` },
+  });
+  if (!reqResp.ok) return json({ error: "requisition lookup failed", detail: await reqResp.text() }, { status: 500 });
+  const reqData = await reqResp.json();
+  const accountId = reqData.accounts?.[0];
+  if (!accountId) return json({ error: "No accounts found on requisition" }, { status: 400 });
+
+  const txResp = await fetch(`${base}/api/v2/accounts/${accountId}/transactions/`, {
+    headers: { Authorization: `Bearer ${access}` },
+  });
+  if (!txResp.ok) return json({ error: "transactions fetch failed", detail: await txResp.text() }, { status: 500 });
+  const txData = await txResp.json();
+  return json({ transactions: txData });
+});


### PR DESCRIPTION
## Summary
- relocate mode selection to landing step
- add per-user link account buttons on the bank review step
- introduce linkAccount helper handling mock or GoCardless data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f7de8e88322822459995872a6a0